### PR TITLE
Fixed issue 71, game startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[!]` Fixed game startup crash when `USER` environment variable is not found in [issue 71](https://github.com/ooxi/violetland/issues/71)
  * `[!]` Improved OpenBSD Support
  * `[+]` As of [issue 64](https://github.com/ooxi/violetland/pull/64) the control style can be toggled between "classic" and "modern"
  * `[*]` Added more available video modes in [issue 63](https://github.com/ooxi/violetland/pull/63), since auto detection doesn't seam to work

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -256,7 +256,19 @@ string getDefaultName() {
 #ifdef _WIN32
 	return DEFAULT_CHAR_NAME;
 #else
-	string name = getenv("USER");
+	
+	// Try to read username from system environment
+	char* user = getenv("USER");
+	
+	// `user' can be null if `USER' environment property not found
+	//
+	// @see http://linux.die.net/man/3/getenv
+	// @see https://github.com/ooxi/violetland/issues/71
+	if (!user) {
+		return DEFAULT_CHAR_NAME;
+	}
+	
+	string name = user;
 	if (name.empty()) {
 		struct passwd *p;
 		uid_t uid;


### PR DESCRIPTION
Game did crash when `USER` environment property was not found. Using default user name instead.