### PR TITLE
Enforce C++98 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,10 @@ add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 add_definitions(-DLOCALE_DIR="${LOCALEDIR}")
 
 
+# Specify C++ standard, I would love to use C++11 but at least on Ubuntu boost
+# is compiled with C++98 which will result in linking errors
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+
 # Compiler diagnostics are most useful
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter")

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -240,9 +240,9 @@ void printVersion() {
 #ifdef _WIN32
 	env = "WINDOWS";
 #endif //_WIN32W
-#ifdef linux
+#ifdef __linux__
 	env = "GNU/LINUX";
-#endif //linux
+#endif //__linux__
 #ifdef __FreeBSD__
 	env = "BSD";
 #endif //__FreeBSD__

--- a/src/system/utility/FileUtility.cpp
+++ b/src/system/utility/FileUtility.cpp
@@ -66,7 +66,7 @@ FileUtility::FileUtility(char *argPath) {
 	m_resPath = m_appPath;
 	m_usrPath = m_resPath;
 #endif //_WIN32
-#if defined linux || defined __FreeBSD__ || defined __OpenBSD__
+#if defined __linux__ || defined __FreeBSD__ || defined __OpenBSD__
 #ifndef INSTALL_PREFIX
 #define INSTALL_PREFIX "/usr/local";
 #endif //INSTALL_PREFIX
@@ -83,7 +83,7 @@ FileUtility::FileUtility(char *argPath) {
 	mkdir(m_usrPath.string().c_str(), S_IRWXU | S_IRGRP | S_IROTH);
 	m_usrPath /= "violetland";
 	mkdir(m_usrPath.string().c_str(), S_IRWXU | S_IRGRP | S_IROTH);
-#endif //linux || __FreeBSD__
+#endif //__linux__ || __FreeBSD__ || defined __OpenBSD__
 	traceResPath();
 }
 


### PR DESCRIPTION
Specify usage of C++98. I would love to enforce C++11 but at least on Ubuntu systems that would result in a linkage error. Furthermore `linux` will not be defined by GCC and Clang, had to change to `__linux__`.