### PR TITLE
Automatic Windows build on Travis CI using MXE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ env:
   matrix:
     - PACKAGES='g++ cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=g++
     - PACKAGES='clang-3.6 cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=clang++
+    - PACKAGES='mxe-x86-64-w64-mingw32.static-gcc cmake mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-sdl mxe-x86-64-w64-mingw32.static-sdl-ttf mxe-x86-64-w64-mingw32.static-sdl-mixer mxe-x86-64-w64-mingw32.static-sdl-image mxe-x86-64-w64-mingw32.static-boost' CMAKE=/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-cmake
 
 before_install:
   - test -n $VIOLET_CXX && export CXX=$VIOLET_CXX
+  - echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+  - sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
   - sudo apt-get update
   - sudo apt-get install -y $PACKAGES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: cpp
-compiler:
-  - clang
-  - gcc
+
+dist: trusty
+
+env:
+  matrix:
+    - PACKAGES='g++ cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=g++
+    - PACKAGES='clang-3.6 cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=clang++
+
 before_install:
+  - test -n $VIOLET_CXX && export CXX=$VIOLET_CXX
   - sudo apt-get update
-  - sudo apt-get install -y cmake libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev
+  - sudo apt-get install -y $PACKAGES
+
 script:
-  - mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../dist .. && make install && cd ..
+  - mkdir build && cd build && $CMAKE -DCMAKE_INSTALL_PREFIX=../dist .. && make install && cd ..
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[+]` [Automatic Windows build using Travis CI and MXE](https://github.com/ooxi/violetland/pull/90)
  * `[*]` [Misc code cleanup](https://github.com/ooxi/violetland/pull/87)
  * `[!]` [Fixed minor bugs](https://github.com/ooxi/violetland/pull/83) enabling Violetland to be build by both GCC and Clang with extra warnings enabled
  * `[!]` [Changing the font to Xolonium-Regular](https://github.com/ooxi/violetland/pull/82) fixed [display issues of german umlauts](https://github.com/ooxi/violetland/issues/81)

--- a/src/system/utility/FileUtility.cpp
+++ b/src/system/utility/FileUtility.cpp
@@ -35,6 +35,7 @@ FileUtility* FileUtility::ofWindows(char const* argvZero) {
  *
  * @return Initialized FileUtility instance for UNIX
  */
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 FileUtility* FileUtility::ofUnix() {
 	
 	/* Application binary
@@ -67,6 +68,7 @@ FileUtility* FileUtility::ofUnix() {
 	
 	return new FileUtility(resources, user);
 }
+#endif
 
 
 


### PR DESCRIPTION
Refactored Travis CI integration to use the [MXE binary distribution](http://pkg.mxe.cc/) in order to automatically build a Windows executable.