### PR TITLE
 Refactor window handling to use boost::function instead of static function pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[*]` [Refactored window handlers to use `boost::function`](https://github.com/ooxi/violetland/pull/91)
  * `[+]` [Automatic Windows build using Travis CI and MXE](https://github.com/ooxi/violetland/pull/90)
  * `[*]` [Misc code cleanup](https://github.com/ooxi/violetland/pull/87)
  * `[!]` [Fixed minor bugs](https://github.com/ooxi/violetland/pull/83) enabling Violetland to be build by both GCC and Clang with extra warnings enabled

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -29,6 +29,7 @@
 #include "SDL_ttf.h"
 
 // Boost
+#include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
@@ -169,7 +170,7 @@ void spawnEnemy(float x, float y, float r, int baseLvl, int lvl) {
 }
 
 // Start the game in selected mode
-void startGame(Window* sender, std::string elementName) {
+void startGame(std::string elementName) {
 	cam->setW(1600);
 
 	hud->reset();
@@ -457,7 +458,7 @@ void shutdownSystem() {
 	delete splash;
 }
 
-void backFromOptionsAndSave(Window* sender, std::string elementName);
+void backFromOptionsAndSave(std::string elementName);
 
 void refreshOptionsWindow() {
 	const int l = videoManager->getVideoMode().Width * 0.1f;
@@ -506,7 +507,7 @@ void refreshOptionsWindow() {
 			13 * h, TextManager::LEFT, TextManager::MIDDLE);
 }
 
-void switchGameOption(Window* sender, std::string elementName) {
+void switchGameOption(std::string elementName) {
 	map<string, bool*> m;
 	m["autoreload"] = &config->AutoReload;
 	m["autopickup"] = &config->AutoWeaponPickup;
@@ -520,7 +521,7 @@ void switchGameOption(Window* sender, std::string elementName) {
 	}
 }
 
-void switchVolumeDown(Window* sender, std::string elementName) {
+void switchVolumeDown(std::string elementName) {
 	if (elementName == "musicvolume") {
 		if (config->MusicVolume > 0) {
 			config->MusicVolume--;
@@ -547,7 +548,7 @@ void switchVolumeDown(Window* sender, std::string elementName) {
 	refreshOptionsWindow();
 }
 
-void switchVolumeUp(Window* sender, std::string elementName) {
+void switchVolumeUp(std::string elementName) {
 	if (elementName == "musicvolume") {
 		if (config->MusicVolume <= 9) {
 			config->MusicVolume++;
@@ -574,7 +575,7 @@ void switchVolumeUp(Window* sender, std::string elementName) {
 	refreshOptionsWindow();
 }
 
-void switchResolutionDown(Window* sender, std::string elementName) {
+void switchResolutionDown(std::string elementName) {
 	vector<SDL_Rect> modes = videoManager->GetAvailableModes();
 
 	bool set = false;
@@ -595,7 +596,7 @@ void switchResolutionDown(Window* sender, std::string elementName) {
 	refreshOptionsWindow();
 }
 
-void switchResolutionUp(Window* sender, std::string elementName) {
+void switchResolutionUp(std::string elementName) {
 	vector<SDL_Rect> modes = videoManager->GetAvailableModes();
 
 	bool set = false;
@@ -618,7 +619,7 @@ void switchResolutionUp(Window* sender, std::string elementName) {
 
 void refreshControlsMenuWindow();
 
-void changeControlStyle(Window* sender, std::string elementName) {
+void changeControlStyle(std::string elementName) {
 	enum ControlStyle style = GetNextControlStyle(config->Control);
 	config->Control = style;
 	
@@ -628,7 +629,7 @@ void changeControlStyle(Window* sender, std::string elementName) {
 	refreshControlsMenuWindow();
 }
 
-void controlsMenuWindowController(Window* sender, std::string elementName);
+void controlsMenuWindowController(std::string elementName);
 
 inline void addControlElement(Window* w, unsigned i, unsigned strN,
 		unsigned lx, unsigned rx) {
@@ -643,7 +644,7 @@ inline void addControlElement(Window* w, unsigned i, unsigned strN,
 	w->addElement(eventId + "key", keyName, videoManager->RegularText, rx, y,
 			TextManager::RIGHT, TextManager::MIDDLE);
 
-	w->addHandler(Window::hdl_lclick, eventId, controlsMenuWindowController);
+	w->addHandler(Window::hdl_lclick, eventId, boost::bind(&controlsMenuWindowController, _1));
 }
 
 void refreshControlsMenuWindow() {
@@ -672,7 +673,7 @@ void refreshControlsMenuWindow() {
 			col1_r,  (videoManager->RegularText->getHeight() + 35) * 2.0f,
 			TextManager::RIGHT, TextManager::MIDDLE
 	);
-	w->addHandler(Window::hdl_lclick, "control-style", changeControlStyle);
+	w->addHandler(Window::hdl_lclick, "control-style", boost::bind(changeControlStyle, _1));
 
 
 	unsigned col1_items = (InputHandler::GameInputEventsCount + 1) / 2;
@@ -704,7 +705,7 @@ void drawWindows() {
 	}
 }
 
-void controlsMenuWindowController(Window* sender, std::string elementName) {
+void controlsMenuWindowController(std::string elementName) {
 	Window *w = new Window(0.0f, 0.0f, config->Screen.Width,
 			config->Screen.Height, 0.0f, 0.0f, 0.0f, 0.5f);
 
@@ -757,9 +758,9 @@ void controlsMenuWindowController(Window* sender, std::string elementName) {
 }
 
 void drawWindows();
-void showHighScores(Window* sender, std::string);
+void showHighScores(std::string);
 
-void createControlsMenuWindow(Window* sender, std::string elementName) {
+void createControlsMenuWindow(std::string elementName) {
 	Window *w = new Window(0.0f, 0.0f, config->Screen.Width,
 			config->Screen.Height, 0.0f, 0.0f, 0.0f, 0.5f);
 
@@ -770,7 +771,7 @@ void createControlsMenuWindow(Window* sender, std::string elementName) {
 	windows["options"]->CloseFlag = true;
 }
 
-void resetControls(Window* sender, std::string elementName) {
+void resetControls(std::string elementName) {
 	Configuration* config_default = new Configuration(fileUtility);
 	for (int i = 0; i < InputHandler::GameInputEventsCount; i++)
 		config->PlayerInputBinding[i] = config_default->PlayerInputBinding[i];
@@ -826,35 +827,35 @@ void createOptionsWindow() {
 	w->addElements(controlsLabels, videoManager->RegularText, r + 2 * h,
 			12 * h, h, TextManager::LEFT, TextManager::MIDDLE);
 
-	w->addHandler(Window::hdl_lclick, "autoreload", switchGameOption);
-	w->addHandler(Window::hdl_lclick, "autopickup", switchGameOption);
-	w->addHandler(Window::hdl_lclick, "friendlyfire", switchGameOption);
-	w->addHandler(Window::hdl_lclick, "soundvolume", switchVolumeUp);
-	w->addHandler(Window::hdl_rclick, "soundvolume", switchVolumeDown);
-	w->addHandler(Window::hdl_lclick, "musicvolume", switchVolumeUp);
-	w->addHandler(Window::hdl_rclick, "musicvolume", switchVolumeDown);
-	w->addHandler(Window::hdl_lclick, "fullscreen", switchGameOption);
-	w->addHandler(Window::hdl_lclick, "resolution", switchResolutionUp);
-	w->addHandler(Window::hdl_rclick, "resolution", switchResolutionDown);
-	w->addHandler(Window::hdl_lclick, "controlsmenu", createControlsMenuWindow);
-	w->addHandler(Window::hdl_lclick, "controlsreset", resetControls);
+	w->addHandler(Window::hdl_lclick, "autoreload", boost::bind(switchGameOption, _1));
+	w->addHandler(Window::hdl_lclick, "autopickup", boost::bind(switchGameOption, _1));
+	w->addHandler(Window::hdl_lclick, "friendlyfire", boost::bind(switchGameOption, _1));
+	w->addHandler(Window::hdl_lclick, "soundvolume", boost::bind(switchVolumeUp, _1));
+	w->addHandler(Window::hdl_rclick, "soundvolume", boost::bind(switchVolumeDown, _1));
+	w->addHandler(Window::hdl_lclick, "musicvolume", boost::bind(switchVolumeUp, _1));
+	w->addHandler(Window::hdl_rclick, "musicvolume", boost::bind(switchVolumeDown, _1));
+	w->addHandler(Window::hdl_lclick, "fullscreen", boost::bind(switchGameOption, _1));
+	w->addHandler(Window::hdl_lclick, "resolution", boost::bind(switchResolutionUp, _1));
+	w->addHandler(Window::hdl_rclick, "resolution", boost::bind(switchResolutionDown, _1));
+	w->addHandler(Window::hdl_lclick, "controlsmenu", boost::bind(createControlsMenuWindow, _1));
+	w->addHandler(Window::hdl_lclick, "controlsreset", boost::bind(resetControls, _1));
 
 	w->addElement("savereturn", _("Save and return"),
 			videoManager->RegularText, l, 16 * h, TextManager::LEFT,
 			TextManager::MIDDLE);
-	w->addHandler(Window::hdl_lclick, "savereturn", backFromOptionsAndSave);
+	w->addHandler(Window::hdl_lclick, "savereturn", boost::bind(backFromOptionsAndSave, _1));
 
 	windows["options"] = w;
 
 	refreshOptionsWindow();
 }
 
-void showOptions(Window* sender, std::string elementName) {
+void showOptions(std::string elementName) {
 	windows["mainmenu"]->CloseFlag = true;
 	createOptionsWindow();
 }
 
-void resumeGame(Window* sender, std::string elementName) {
+void resumeGame(std::string elementName) {
 	Window* w = windows.find("mainmenu")->second;
 	w->CloseFlag = true;
 	switchGamePause();
@@ -880,7 +881,7 @@ void refreshMainMenuWindow() {
 			TextManager::MIDDLE);
 }
 
-void switchGameMode(Window* sender, std::string elementName) {
+void switchGameMode(std::string elementName) {
 	switch (gameMode) {
 	case GAMEMODE_SURVIVAL:
 		gameMode = GAMEMODE_WAVES;
@@ -899,11 +900,11 @@ void createMainMenuWindow() {
 	Window *mainMenu = new MainMenuWindow(config, gameState,
 			videoManager->RegularText);
 
-	mainMenu->addHandler(Window::hdl_lclick, "resume", resumeGame);
-	mainMenu->addHandler(Window::hdl_lclick, "start", startGame);
-	mainMenu->addHandler(Window::hdl_lclick, "gamemode", switchGameMode);
-	mainMenu->addHandler(Window::hdl_lclick, "options", showOptions);
-	mainMenu->addHandler(Window::hdl_lclick, "highscores", showHighScores);
+	mainMenu->addHandler(Window::hdl_lclick, "resume", boost::bind(resumeGame, _1));
+	mainMenu->addHandler(Window::hdl_lclick, "start", boost::bind(startGame, _1));
+	mainMenu->addHandler(Window::hdl_lclick, "gamemode", boost::bind(switchGameMode, _1));
+	mainMenu->addHandler(Window::hdl_lclick, "options", boost::bind(showOptions, _1));
+	mainMenu->addHandler(Window::hdl_lclick, "highscores", boost::bind(showHighScores, _1));
 
 	std::map<std::string, Window*>::iterator it = windows.find("mainmenu");
 	if (it != windows.end())
@@ -913,14 +914,14 @@ void createMainMenuWindow() {
 	refreshMainMenuWindow();
 }
 
-void highScoresWindowController(Window* sender, std::string elementName) {
+void highScoresWindowController(std::string elementName) {
 	if (elementName == "back") {
 		windows["highscores"]->CloseFlag = true;
 		createMainMenuWindow();
 	} else if (elementName == "reset") {
 		Highscores s(fileUtility);
 		s.clear();
-		highScoresWindowController(sender, "back");
+		highScoresWindowController("back");
 	}
 }
 
@@ -988,14 +989,14 @@ void createHighscoresWindow() {
 	w->addElement("reset", _("Reset list"), videoManager->RegularText, r3,
 			16 * h, TextManager::LEFT, TextManager::MIDDLE);
 
-	w->addHandler(Window::hdl_lclick, "back", highScoresWindowController);
+	w->addHandler(Window::hdl_lclick, "back", boost::bind(highScoresWindowController, _1));
 
-	w->addHandler(Window::hdl_lclick, "reset", highScoresWindowController);
+	w->addHandler(Window::hdl_lclick, "reset", boost::bind(highScoresWindowController, _1));
 
 	windows["highscores"] = w;
 }
 
-void showHighScores(Window* sender, std::string elementName) {
+void showHighScores(std::string elementName) {
 	windows["mainmenu"]->CloseFlag = true;
 	createHighscoresWindow();
 }
@@ -1012,7 +1013,7 @@ void unloadResources() {
 	delete config;
 }
 
-void backFromOptionsAndSave(Window* sender, std::string elementName) {
+void backFromOptionsAndSave(std::string elementName) {
 	bool changeVideoMode = config->Screen.Width != tempConfig->Screen.Width
 			|| config->Screen.Height != tempConfig->Screen.Height;
 

--- a/src/windows/CharStatsWindow.cpp
+++ b/src/windows/CharStatsWindow.cpp
@@ -1,3 +1,4 @@
+#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <libintl.h>
@@ -28,40 +29,19 @@ const char* CharStatsWindow::paramIds[] = {
 
 const unsigned CharStatsWindow::paramIdsNumber = sizeof(CharStatsWindow::paramIds) / sizeof(char*);
 
-void CharStatsWindow::onPlayerParamClickEvent(Window* sender, string paramName)
+void CharStatsWindow::onPlayerParamClickEvent(string paramName)
 {
-	CharStatsWindow* window = dynamic_cast<CharStatsWindow*>(sender);
-	
-	if (NULL == window) {
-		std::cerr << "onPlayerParamClickEvent was called with unexpected sender" << std::endl;
-		return;
-	}
-	
-	window->increasePlayerParam(paramName);
+	increasePlayerParam(paramName);
 }
 
-void CharStatsWindow::onPerkHoverEvent(Window* sender, string perkName)
+void CharStatsWindow::onPerkHoverEvent(string perkName)
 {
-	CharStatsWindow* window = dynamic_cast<CharStatsWindow*>(sender);
-	
-	if (NULL == window) {
-		std::cerr << "onPerkHoverEvent was called with unexpected sender" << std::endl;
-		return;
-	}
-	
-	window->showPerkDetails(perkName);
+	showPerkDetails(perkName);
 }
 
-void CharStatsWindow::onPerkClickEvent(Window* sender, string perkName)
+void CharStatsWindow::onPerkClickEvent(string perkName)
 {
-	CharStatsWindow* window = dynamic_cast<CharStatsWindow*>(sender);
-	
-	if (NULL == window) {
-		std::cerr << "onPerkClickEvent was called with unexpected sender" << std::endl;
-		return;
-	}
-	
-	window->givePerkToPlayer(perkName);
+	givePerkToPlayer(perkName);
 }
 
 CharStatsWindow::CharStatsWindow(Configuration* config,
@@ -107,12 +87,13 @@ CharStatsWindow::CharStatsWindow(Configuration* config,
 	m_perkDetails["magneto"] = _("Magneto: useful things slowly move "
 			"towards you.");
 
-	for (unsigned i = 0; i < paramIdsNumber; ++i)
-			addHandler(Window::hdl_lclick, paramIds[i], onPlayerParamClickEvent);
+	for (unsigned i = 0; i < paramIdsNumber; ++i) {
+		addHandler(Window::hdl_lclick, paramIds[i], boost::bind(&CharStatsWindow::onPlayerParamClickEvent, this, _1));
+	}
 
 	for (unsigned i = 0; i < perkIdsNumber; ++i) {
-		addHandler(Window::hdl_move, perkIds[i], onPerkHoverEvent);
-		addHandler(Window::hdl_lclick, perkIds[i], onPerkClickEvent);
+		addHandler(Window::hdl_move, perkIds[i], boost::bind(&CharStatsWindow::onPerkHoverEvent, this, _1));
+		addHandler(Window::hdl_lclick, perkIds[i], boost::bind(&CharStatsWindow::onPerkClickEvent, this, _1));
 	}
 }
 

--- a/src/windows/CharStatsWindow.h
+++ b/src/windows/CharStatsWindow.h
@@ -14,15 +14,16 @@ class CharStatsWindow: public Window {
 	void increasePlayerParam(std::string paramName);
 	void showPerkDetails(std::string perkName);
 	void givePerkToPlayer(std::string perkName);
+	
+	void onPlayerParamClickEvent(std::string paramName);
+	void onPerkHoverEvent(std::string perkName);
+	void onPerkClickEvent(std::string perkName);
+	
 public:
 	static const char* perkIds[];
 	static const unsigned perkIdsNumber;
 	static const char* paramIds[];
 	static const unsigned paramIdsNumber;
-
-	static void onPlayerParamClickEvent(Window* sender, std::string paramName);
-	static void onPerkHoverEvent(Window* sender, std::string perkName);
-	static void onPerkClickEvent(Window* sender, std::string perkName);
 
 	CharStatsWindow(Configuration* config, VideoManager* videoManager,
 			Player* player);

--- a/src/windows/MainMenuWindow.cpp
+++ b/src/windows/MainMenuWindow.cpp
@@ -1,3 +1,5 @@
+#include <boost/bind.hpp>
+
 #include "MainMenuWindow.h"
 #include <libintl.h>
 #include <locale.h>
@@ -27,7 +29,7 @@ MainMenuWindow::MainMenuWindow(Configuration* config, GameState* gameState,
 	addElements(labels, text, 
 			l, 7*h, h, TextManager::LEFT, TextManager::MIDDLE);
 
-	addHandler(Window::hdl_lclick, "exit", onMenuItemClick);
+	addHandler(Window::hdl_lclick, "exit", boost::bind(&MainMenuWindow::onMenuItemClick, this, _1));
 }
 
 void MainMenuWindow::exitGame()
@@ -35,17 +37,10 @@ void MainMenuWindow::exitGame()
 	m_gameState->end();
 }
 
-void MainMenuWindow::onMenuItemClick(Window* sender, string menuItem)
+void MainMenuWindow::onMenuItemClick(string menuItem)
 {
-	MainMenuWindow* window = dynamic_cast<MainMenuWindow*>(sender);
-		
-	if (NULL == window) {
-		std::cerr << "onMenuItemClick was called with unexpected sender" << std::endl;
-		return;
-	}
-
 	if (menuItem == "exit")
-		window->exitGame();
+		exitGame();
 }
 
 MainMenuWindow::~MainMenuWindow() {

--- a/src/windows/MainMenuWindow.h
+++ b/src/windows/MainMenuWindow.h
@@ -11,10 +11,10 @@ class MainMenuWindow: public Window {
 private:
 	GameState* m_gameState;
 
+	void onMenuItemClick(std::string menuItem);
 	void exitGame();
 
 public:
-	static void onMenuItemClick(Window* sender, std::string menuItem);
 
 	MainMenuWindow(Configuration* config, GameState* gameState,
 			TextManager* text);

--- a/src/windows/Window.cpp
+++ b/src/windows/Window.cpp
@@ -53,29 +53,29 @@ void Window::removeElement(std::string name, bool remainHandler) {
 		removeHandler(hdl_click, name);
 }
 
-void Window::addHandler(HandlerType hdl, std::string elementName, void(*func)(Window* sender, std::string elementName)) {
+void Window::addHandler(HandlerType hdl, std::string elementName, boost::function<void (std::string)> handler) {
 	removeHandler(hdl, elementName);
 	if (hdl == hdl_click || hdl == hdl_lclick)
-		m_lcHandlers[elementName] = func;
+		m_lcHandlers[elementName] = handler;
 	if (hdl == hdl_click || hdl == hdl_rclick)
-		m_rcHandlers[elementName] = func;
+		m_rcHandlers[elementName] = handler;
 	if (hdl == hdl_move)
-		m_mvHandlers[elementName] = func;
+		m_mvHandlers[elementName] = handler;
 }
 
 void Window::removeHandler(HandlerType hdl, std::string elementName) {
 	if (hdl == hdl_all || hdl == hdl_click || hdl == hdl_lclick) {
-		std::map<std::string, void(*)(Window* sender, std::string elementName)>::iterator it = m_lcHandlers.find(elementName);
+		std::map<std::string, boost::function<void (std::string)> >::iterator it = m_lcHandlers.find(elementName);
 		if (it != m_lcHandlers.end())
 			m_lcHandlers.erase(elementName);
 	}
 	if (hdl == hdl_all || hdl == hdl_click || hdl == hdl_rclick) {
-		std::map<std::string, void(*)(Window* sender, std::string elementName)>::iterator it = m_rcHandlers.find(elementName);
+		std::map<std::string, boost::function<void (std::string)> >::iterator it = m_rcHandlers.find(elementName);
 		if (it != m_rcHandlers.end())
 			m_rcHandlers.erase(elementName);
 	}
 	if (hdl == hdl_all || hdl == hdl_move) {
-		std::map<std::string, void(*)(Window* sender, std::string elementName)>::iterator it = m_mvHandlers.find(elementName);
+		std::map<std::string, boost::function<void (std::string)> >::iterator it = m_mvHandlers.find(elementName);
 		if (it != m_mvHandlers.end())
 			m_mvHandlers.erase(elementName);
 	}
@@ -117,14 +117,15 @@ void Window::process(InputHandler* input) {
 	int gmy = input->mouseY;
 
 	// Mouse hover handlers
-	std::map<std::string, void(*)(Window* sender, std::string)>::const_iterator iter;
+	std::map<std::string, boost::function<void (std::string)> >::const_iterator iter;
+	
 	for (iter = m_mvHandlers.begin(); iter != m_mvHandlers.end(); ++iter) {
 		std::map<std::string, TextObject*>::iterator it = m_elements.find(iter->first);
 		if (it != m_elements.end()) {
 			TextObject* o = it->second;
 			if (gmx > o->getLeft() && gmx < o->getRight() && gmy > o->getTop()
 					&& gmy < o->getBottom()) {
-				iter->second(this, iter->first);
+				iter->second(iter->first);
 
 				// Be careful, callback function (iter->second) can change set of handlers or even replace all handlers and iter will be not incrementable anymore!
 				break;
@@ -141,7 +142,7 @@ void Window::process(InputHandler* input) {
 					&& gmy < o->getBottom()) {
 				o->GMask = 0.3f;
 				if (input->getPressInput(InputHandler::MenuClickA)) {
-					iter->second(this, iter->first);
+					iter->second(iter->first);
 					
 					// Be careful, callback function (iter->second) can change set of handlers or even replace all handlers and iter will be not incrementable anymore!
 					break;
@@ -161,7 +162,7 @@ void Window::process(InputHandler* input) {
 					&& gmy < o->getBottom()) {
 				o->RMask = 0.3f;
 				if (input->getPressInput(InputHandler::MenuClickB)) {
-					iter->second(this, iter->first);
+					iter->second(iter->first);
 
 					// Be careful, callback function (iter->second) can change set of handlers or even replace all handlers and iter will be not incrementable anymore!
 					break;
@@ -177,4 +178,5 @@ Window::~Window() {
 	clearMap(&m_elements);
 	m_lcHandlers.clear();
 	m_rcHandlers.clear();
+	m_mvHandlers.clear();
 }

--- a/src/windows/Window.h
+++ b/src/windows/Window.h
@@ -1,6 +1,7 @@
 #ifndef WINDOW_H_
 #define WINDOW_H_
 
+#include <boost/function.hpp>
 #include <map>
 #include <string>
 #include "../system/graphic/text/TextObject.h"
@@ -11,9 +12,10 @@ class Window {
 protected:
 	float m_left, m_top, m_right, m_bottom, m_r, m_g, m_b, m_a;
 	std::map<std::string, TextObject*> m_elements;
-	std::map<std::string, void(*)(Window* sender, std::string elementName)> m_lcHandlers;
-	std::map<std::string, void(*)(Window* sender, std::string elementName)> m_rcHandlers;
-	std::map<std::string, void(*)(Window* sender, std::string elementName)> m_mvHandlers;
+
+	std::map<std::string, boost::function<void (std::string)> > m_lcHandlers;
+	std::map<std::string, boost::function<void (std::string)> > m_rcHandlers;
+	std::map<std::string, boost::function<void (std::string)> > m_mvHandlers;
 public:
 	enum HandlerType {
 		hdl_all = 0, hdl_click, hdl_lclick, hdl_rclick, hdl_move
@@ -30,8 +32,7 @@ public:
 			TextManager* manager, int x, int y, int vstep, 
 			TextManager::TextHAlignFlag halign, TextManager::TextVAlignFlag valign);
 	void removeElement(std::string name, bool remainHandler);
-	//	void addHandler(HandlerType hdl, std::string elementName, void(*func)());
-	void addHandler(HandlerType hdl, std::string elementName, void(*func)(Window* sender, std::string elementName));
+	void addHandler(HandlerType hdl, std::string elementName, boost::function<void(std::string)> handler);
 	void removeHandler(HandlerType hdl, std::string elementName);
 	void process(InputHandler* input);
 	void draw();


### PR DESCRIPTION
Therefore no dynamic casting and type checking at runtime is necessary. Furthermore handlers can easily contain state and accept more arguments.