### PR TITLE
Refactored Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,17 @@ language: cpp
 dist: trusty
 
 env:
+  global:
+     - secure: "aRxEKBXnGy2PWEYtjVX9wBKFIsX738w44/h+8cJX8Tqr5dUNuJ5SzXqvavjrM8guTi8GMh1DgtTcwYIlc+RbjQ1U6ynFeP4BBveYMhyI/18A4EZsIFjcAQ9oaoqLBl8YR77Lk7GVEEohvRjfbdNfnyldjRQe5rSuI2c7s/xlQAk="
+
   matrix:
-    - PACKAGES='g++ cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=g++
-    - PACKAGES='clang-3.6 cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev' CMAKE=cmake VIOLET_CXX=clang++
-    - PACKAGES='mxe-i686-w64-mingw32.static-gcc cmake mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-sdl mxe-i686-w64-mingw32.static-sdl-ttf mxe-i686-w64-mingw32.static-sdl-mixer mxe-i686-w64-mingw32.static-sdl-image mxe-i686-w64-mingw32.static-boost' CMAKE=/usr/lib/mxe/usr/bin/i686-w64-mingw32.static-cmake
-    - PACKAGES='mxe-x86-64-w64-mingw32.static-gcc cmake mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-sdl mxe-x86-64-w64-mingw32.static-sdl-ttf mxe-x86-64-w64-mingw32.static-sdl-mixer mxe-x86-64-w64-mingw32.static-sdl-image mxe-x86-64-w64-mingw32.static-boost' CMAKE=/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-cmake
+     - TARGET='trusty-amd64-clang'
+     - TARGET='trusty-amd64-gcc'
+     - TARGET='windows-amd64'
+     - TARGET='windows-i686'
 
 before_install:
-  - test -n $VIOLET_CXX && export CXX=$VIOLET_CXX
-  - echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
-  - sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
-  - sudo apt-get update
-  - sudo apt-get install -y $PACKAGES
+  - ./deploy/travis-ci/$TARGET/before-install.sh
 
 script:
-  - mkdir build && cd build && $CMAKE -DCMAKE_INSTALL_PREFIX=../dist .. && make install && cd ..
-
+  - ./deploy/travis-ci/$TARGET/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ before_install:
 
 script:
   - ./deploy/travis-ci/$TARGET/script.sh
+
+after_success:
+ - ./deploy/travis-ci/$TARGET/after-success.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[+]` [Automatic windows builds](https://github.com/ooxi/violetland/pull/105), deploying Windows development snapshots to [Bintray](https://dl.bintray.com/ooxi/violetland/travis-ci/)
  * `[*]` [Improved M-32 reload sound](https://github.com/ooxi/violetland/pull/101)
  * `[*]` [Window subsystem refactored](https://github.com/ooxi/violetland/pull/96), moved window creation from `program.cpp` to individual subclasses
  * `[+]` [bla-rs](https://github.com/bla-rs) added [weapon documentation](https://github.com/ooxi/violetland/pull/98)

--- a/deploy/travis-ci/travis-ci.sh
+++ b/deploy/travis-ci/travis-ci.sh
@@ -15,3 +15,130 @@ DIRECTORY_OF_TRAVIS_CI_SH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIRECTORY="${DIRECTORY_OF_TRAVIS_CI_SH}/../.."
 BUILD_DIRECTORY="${ROOT_DIRECTORY}/build"
 DIST_DIRECTORY="${ROOT_DIRECTORY}/dist"
+
+
+
+#
+# Common environment
+# ==================
+#
+# BUILD_DATE		2016-01-22
+# TARGET		trusty-amd64-gcc
+# VERSION		0.5
+# TRAVIS_BUILD_NUMBER	167
+# TRAVIS_COMMIT		b6b90f7d2e8b7fdd4d1a62b59c7822ea160f9491
+#
+
+BUILD_DATE=`date --iso-8601`
+VERSION=`head -n 1 ${DIRECTORY_OF_TRAVIS_CI_SH}/../../VERSION`
+
+
+
+#
+# Environment when building master
+# ================================
+# 
+# TRAVIS_BRANCH		master
+# TRAVIS_PULL_REQUEST	false
+#
+# ARTIFACT_NAME		violetland-0.5-b167-trusty-amd64-gcc
+#
+
+if [ "master" == "${TRAVIS_BRANCH}" ] && [ "false" == "${TRAVIS_PULL_REQUEST}" ]; then
+	BINTRAY_VERSION="${TRAVIS_BUILD_NUMBER}"
+	BINTRAY_DIRECTORY="travis-ci/master/${BINTRAY_VERSION}"
+	BINTRAY_FILE="violetland-${VERSION}-b${TRAVIS_BUILD_NUMBER}-${TARGET}"
+fi
+
+
+
+#
+# Environment when building a different branch
+# =============================================
+#
+# TRAVIS_BRANCH		feature/automatic-windows-deployment
+# TRAVIS_PULL_REQUEST	false
+#
+# ARTIFACT_NAME		branch-feature_automatic-windows-deployment-b167-trusty-amd64-gcc
+#
+
+if [ "master" != "${TRAVIS_BRANCH}" ] && [ "false" == "${TRAVIS_PULL_REQUEST}" ]; then
+
+	BINTRAY_VERSION="${TRAVIS_BUILD_NUMBER}"
+	BINTRAY_DIRECTORY="travis-ci/branches/${TRAVIS_BRANCH}"
+	BINTRAY_FILE="violetland-${VERSION}-b${TRAVIS_BUILD_NUMBER}-${TARGET}-${TRAVIS_COMMIT:0:7}"
+fi
+
+
+
+#
+# Environment when building a pull request
+# ========================================
+#
+# TRAVIS_BRANCH		master
+# TRAVIS_PULL_REQUEST	104
+# 
+# ARTIFACT_NAME		pull-request-104-b167-b6b90f7-trusty-amd64-gcc
+#
+
+if [ "false" != "${TRAVIS_PULL_REQUEST}" ]; then
+
+	BINTRAY_VERSION="${TRAVIS_BUILD_NUMBER}"
+	BINTRAY_DIRECTORY="travis-ci/pull-requests/${TRAVIS_PULL_REQUEST}"
+	BINTRAY_FILE="violetland-${VERSION}-b${TRAVIS_BUILD_NUMBER}-${TARGET}-${TRAVIS_COMMIT:0:7}"
+fi
+
+
+
+
+
+#
+# Deploy ${DIST_DIRECTORY} as `.tar.bz2' to Bintray
+#
+function deploy_as_tarbz2 {
+	if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
+		echo "Will deploy artifact ${ARTIFACT_NAME} to Bintray"
+		
+		sudo apt-get install -y curl tar bzip2
+		mv "${DIST_DIRECTORY}" "${ROOT_DIRECTORY}/${BINTRAY_FILE}"
+		tar -cjvf "${BUILD_DIRECTORY}/${BINTRAY_FILE}.tar.bz2" "${ROOT_DIRECTORY}/${BINTRAY_FILE}"
+
+		BINTRAY_RESPONSE=`curl -T "${BUILD_DIRECTORY}/${BINTRAY_FILE}.tar.bz2" "-uooxi:${BINTRAY_DEPLOYMENT_API_KEY}" "https://api.bintray.com/content/ooxi/violetland/travis-ci/${BINTRAY_VERSION}/${BINTRAY_DIRECTORY}/${BINTRAY_FILE}.tar.bz2?publish=1"`
+
+		if [ '{"message":"success"}' == "${BINTRAY_RESPONSE}" ]; then
+			echo "Artifact published at https://dl.bintray.com/ooxi/violetland/${BINTRAY_DIRECTORY}/${BINTRAY_FILE}.tar.bz2"
+		else
+			echo "Depolyment to Bintray failed with response ${BINTRAY_RESPONSE}"
+			exit 1
+		fi
+	fi
+}
+
+
+
+#
+# Deploy ${DIST_DIRECTORY} as `.zip' to Bintray
+#
+function deploy_as_zip {
+	if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
+		echo "Will deploy artifact ${ARTIFACT_NAME} to Bintray"
+		
+		# TODO directoy structure should be created by install script not
+		#      during deployment
+		mv "${DIST_DIRECTORY}/bin/violetland.exe" "${DIST_DIRECTORY}/share/violetland/violetland.exe"
+		
+		# @see http://stackoverflow.com/a/20545763
+		sudo apt-get install -y curl p7zip-full
+		7z a -tzip "${BUILD_DIRECTORY}/${BINTRAY_FILE}.zip" -w "${DIST_DIRECTORY}/share/violetland"
+
+		BINTRAY_RESPONSE=`curl -T "${BUILD_DIRECTORY}/${BINTRAY_FILE}.zip" "-uooxi:${BINTRAY_DEPLOYMENT_API_KEY}" "https://api.bintray.com/content/ooxi/violetland/travis-ci/${BINTRAY_VERSION}/${BINTRAY_DIRECTORY}/${BINTRAY_FILE}.zip?publish=1"`
+
+		if [ '{"message":"success"}' == "${BINTRAY_RESPONSE}" ]; then
+			echo "Artifact published at https://dl.bintray.com/ooxi/violetland/${BINTRAY_DIRECTORY}/${BINTRAY_FILE}.zip"
+		else
+			echo "Depolyment to Bintray failed with response ${BINTRAY_RESPONSE}"
+			exit 1
+		fi
+	fi
+}
+

--- a/deploy/travis-ci/travis-ci.sh
+++ b/deploy/travis-ci/travis-ci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_TRAVIS_CI_SH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+
+#
+# Resolve directories
+# ===================
+#
+ROOT_DIRECTORY="${DIRECTORY_OF_TRAVIS_CI_SH}/../.."
+BUILD_DIRECTORY="${ROOT_DIRECTORY}/build"
+DIST_DIRECTORY="${ROOT_DIRECTORY}/dist"

--- a/deploy/travis-ci/trusty-amd64-clang/after-success.sh
+++ b/deploy/travis-ci/trusty-amd64-clang/after-success.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Deploy
+deploy_as_tarbz2

--- a/deploy/travis-ci/trusty-amd64-clang/before-install.sh
+++ b/deploy/travis-ci/trusty-amd64-clang/before-install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Install dependencies
+PACKAGES='clang-3.6 cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev'
+
+sudo apt-get update
+sudo apt-get install -y $PACKAGES

--- a/deploy/travis-ci/trusty-amd64-clang/script.sh
+++ b/deploy/travis-ci/trusty-amd64-clang/script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Build
+CMAKE=cmake
+CXX=clang++
+
+mkdir "${BUILD_DIRECTORY}" && cd "${BUILD_DIRECTORY}" && $CMAKE -DCMAKE_INSTALL_PREFIX=${DIST_DIRECTORY} "${ROOT_DIRECTORY}" && make install

--- a/deploy/travis-ci/trusty-amd64-gcc/after-success.sh
+++ b/deploy/travis-ci/trusty-amd64-gcc/after-success.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Deploy
+deploy_as_tarbz2

--- a/deploy/travis-ci/trusty-amd64-gcc/before-install.sh
+++ b/deploy/travis-ci/trusty-amd64-gcc/before-install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Install dependencies
+PACKAGES='g++ cmake gettext libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev'
+
+sudo apt-get update
+sudo apt-get install -y $PACKAGES

--- a/deploy/travis-ci/trusty-amd64-gcc/script.sh
+++ b/deploy/travis-ci/trusty-amd64-gcc/script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Build
+CMAKE=cmake
+CXX=g++
+
+mkdir "${BUILD_DIRECTORY}" && cd "${BUILD_DIRECTORY}" && $CMAKE -DCMAKE_INSTALL_PREFIX=${DIST_DIRECTORY} "${ROOT_DIRECTORY}" && make install

--- a/deploy/travis-ci/windows-amd64/after-success.sh
+++ b/deploy/travis-ci/windows-amd64/after-success.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Deploy
+deploy_as_zip

--- a/deploy/travis-ci/windows-amd64/before-install.sh
+++ b/deploy/travis-ci/windows-amd64/before-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Install dependencies
+PACKAGES='mxe-x86-64-w64-mingw32.static-gcc cmake mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-sdl mxe-x86-64-w64-mingw32.static-sdl-ttf mxe-x86-64-w64-mingw32.static-sdl-mixer mxe-x86-64-w64-mingw32.static-sdl-image mxe-x86-64-w64-mingw32.static-boost'
+
+echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+
+sudo apt-get update
+sudo apt-get install -y $PACKAGES

--- a/deploy/travis-ci/windows-amd64/script.sh
+++ b/deploy/travis-ci/windows-amd64/script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Build
+CMAKE=/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-cmake
+CXX=g++
+
+mkdir "${BUILD_DIRECTORY}" && cd "${BUILD_DIRECTORY}" && $CMAKE -DCMAKE_INSTALL_PREFIX=${DIST_DIRECTORY} "${ROOT_DIRECTORY}" && make install
+

--- a/deploy/travis-ci/windows-i686/after-success.sh
+++ b/deploy/travis-ci/windows-i686/after-success.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Deploy
+deploy_as_zip

--- a/deploy/travis-ci/windows-i686/before-install.sh
+++ b/deploy/travis-ci/windows-i686/before-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Install dependencies
+PACKAGES='mxe-i686-w64-mingw32.static-gcc cmake mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-sdl mxe-i686-w64-mingw32.static-sdl-ttf mxe-i686-w64-mingw32.static-sdl-mixer mxe-i686-w64-mingw32.static-sdl-image mxe-i686-w64-mingw32.static-boost'
+
+echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+
+sudo apt-get update
+sudo apt-get install -y $PACKAGES

--- a/deploy/travis-ci/windows-i686/script.sh
+++ b/deploy/travis-ci/windows-i686/script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+
+# @see http://stackoverflow.com/a/246128/2534648
+DIRECTORY_OF_THIS_FILE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
+
+
+# Build
+CMAKE=/usr/lib/mxe/usr/bin/i686-w64-mingw32.static-cmake
+CXX=g++
+
+mkdir "${BUILD_DIRECTORY}" && cd "${BUILD_DIRECTORY}" && $CMAKE -DCMAKE_INSTALL_PREFIX=${DIST_DIRECTORY} "${ROOT_DIRECTORY}" && make install
+


### PR DESCRIPTION
In order to enable automatic windows builds (binary artifacts) the `.travis.yml` file was split up in several bash scripts to increase maintainability. For every `TARGET` (e.g. `trusty-amd64-gcc`) three scripts are run

 1. `before-install.sh`: install all dependencies and in case of MXE also add the required repositories
 2. `script.sh`: select the right build tools to compile violetland
 3. `after-success.sh`: package binary artifacts and upload to Bintray
