### PR TITLE
Windows binary includes icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ Legend
 Upcoming release
 ----------------
 
+ * `[+]` [Icon for Windows executables](https://github.com/ooxi/violetland/pull/109)
  * `[+]` [Isolated build environment](https://github.com/ooxi/violetland/pull/107) using [Vagrant](https://www.vagrantup.com/)
- * `[+]` [Automatic windows builds](https://github.com/ooxi/violetland/pull/105), deploying Windows development snapshots to [Bintray](https://dl.bintray.com/ooxi/violetland/travis-ci/)
+ * `[+]` [Automatic Windows builds](https://github.com/ooxi/violetland/pull/105), deploying Windows development snapshots to [Bintray](https://dl.bintray.com/ooxi/violetland/travis-ci/)
  * `[*]` [Improved M-32 reload sound](https://github.com/ooxi/violetland/pull/101)
  * `[*]` [Window subsystem refactored](https://github.com/ooxi/violetland/pull/96), moved window creation from `program.cpp` to individual subclasses
  * `[+]` [bla-rs](https://github.com/bla-rs) added [weapon documentation](https://github.com/ooxi/violetland/pull/98)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,15 @@ add_definitions(-DVIOLETLAND_VERSION="${VIOLETLAND_VERSION}")
 
 
 
+# Windows resources
+set(VIOLET_RESOURCE_DIR rc)
+
+set(VIOLET_RESOURCES
+	# rc/
+	${VIOLET_RESOURCE_DIR}/icon.rc
+)
+
+
 # Sources, ordered by
 #
 #  1) first files, than directories
@@ -186,7 +195,7 @@ endif()
 
 # Build executable
 include_directories(${VIOLET_INCLUDE_DIRS})
-add_executable(violetland ${VIOLET_SOURCES})
+add_executable(violetland ${VIOLET_RESOURCES} ${VIOLET_SOURCES})
 target_link_libraries(violetland ${VIOLET_LIBRARIES})
 
 

--- a/rc/icon.rc
+++ b/rc/icon.rc
@@ -1,0 +1,2 @@
+id ICON "../icon-light.ico"
+


### PR DESCRIPTION
Using [ICON resource](https://msdn.microsoft.com/en-us/library/windows/desktop/aa381018%28v=vs.85%29.aspx) to embed `icon-light.ico` as executable icon for Windows binaries.