### PR TITLE
Instruct gcc to use Windows GUI subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[+]` [Windows executable uses GUI subsystem](https://github.com/ooxi/violetland/pull/111) thus not spawning a console
  * `[+]` [Icon for Windows executables](https://github.com/ooxi/violetland/pull/109)
  * `[+]` [Isolated build environment](https://github.com/ooxi/violetland/pull/107) using [Vagrant](https://www.vagrantup.com/)
  * `[+]` [Automatic Windows builds](https://github.com/ooxi/violetland/pull/105), deploying Windows development snapshots to [Bintray](https://dl.bintray.com/ooxi/violetland/travis-ci/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,24 @@ endif()
 
 
 
+# Generated executable should use the GUI subsystem on Windows instead of the
+# character subsystem (thus not spawning a console window).
+#
+# @see https://msdn.microsoft.com/en-us/windows/hardware/gg463119.aspx
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+
+	# GCC's `-mwindows` will instruct the linker to set the PE header subsystem
+	# type appropriately
+	#
+	# @see https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/x86-Windows-Options.html#x86-Windows-Options
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mwindows")
+	endif()
+
+endif()
+
+
+
 # Build executable
 include_directories(${VIOLET_INCLUDE_DIRS})
 add_executable(violetland ${VIOLET_RESOURCES} ${VIOLET_SOURCES})


### PR DESCRIPTION
GCC's [`-mwindows` flag](https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/x86-Windows-Options.html#x86-Windows-Options) can be used to instruct the linker to create an executable using the `IMAGE_SUBSYSTEM_WINDOWS_GUI` [Windows subsystem](https://msdn.microsoft.com/en-us/windows/hardware/gg463119.aspx). There is no equivalent flagt for Linux executables and I do not yet know a way to instruct Clang to do the same (but [asked on Stackoverflow](http://stackoverflow.com/questions/35057242/clangs-equivalent-to-gccs-mwindows)).