### PR TITLE
Reduced XP requirement for next level in later game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[*]` [Violet will level up faster](https://github.com/ooxi/violetland/pull/115)
  * `[+]` [Windows executable uses GUI subsystem](https://github.com/ooxi/violetland/pull/111) thus not spawning a console
  * `[+]` [Icon for Windows executables](https://github.com/ooxi/violetland/pull/109)
  * `[+]` [Isolated build environment](https://github.com/ooxi/violetland/pull/107) using [Vagrant](https://www.vagrantup.com/)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,7 +3,8 @@ violetland contributors (sorted alphabeticaly)
 
 * **[bla-rs](https://github.com/bla-rs)**
 
-	 * Documentation
+	 * [Gameplay balancing](https://github.com/ooxi/violetland/pull/115)
+	 * [Weapon Documentation](https://github.com/ooxi/violetland/pull/98)
 
 * **Charlie Hron Weigle**
 

--- a/src/game/lifeforms/Player.cpp
+++ b/src/game/lifeforms/Player.cpp
@@ -12,7 +12,7 @@ Player::Player(float x, float y, Sprite *legsSprite, Sprite *deathSprite,
 	Id = "20-" + Id;
 	Xp = 0;
 	LastLevelXp = 0;
-	NextLevelXp = 100;
+	NextLevelXp = 200;
 	Kills = 0;
 	LevelPoints = 0;
 	ActionMode = PLAYER_ACT_MODE_FIRE;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1011,7 +1011,7 @@ void levelUp(Player* player) {
 				player->Level * 2.0f + 15);
 
 	player->LastLevelXp = player->NextLevelXp;
-	player->NextLevelXp *= 2;
+	player->NextLevelXp *= 1.3;
 
 	player->Level += 1;
 	player->LevelPoints += 1;


### PR DESCRIPTION
Changed the required xp per level from

	old_xp(level) = 100 * level^2

to

	new_xp(level) = 200 * level^1.3

Which requires more XP / level below level three but then reduced XP.

![level-xp](https://cloud.githubusercontent.com/assets/2611835/12703920/4b648e86-c84f-11e5-9e7f-e685e4b494e4.png)

`old_xp` is blue, `new_xp` is red. x-axis is level, y-axis is required XP.