### PR TITLE
Change `LifeForm::WeaponRetForceMod`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -136,7 +136,7 @@ const float LifeForm::ReloadSpeedMod() const {
 }
 
 const float LifeForm::WeaponRetForceMod() const {
-	return getStrength() > 1.0f ? 1.0f - (getStrength() - 1.0f) * 1.1f : 1.0f;
+	return 1.0f - ( getStrength() - 1.0f ) / ( getStrength() + 1.0f );
 }
 
 const float LifeForm::fixHealth(float health) const {


### PR DESCRIPTION
Old formula

	wep-ret_old(str) = if   str > 1 → 1 - (str - 1) * 1.1
                       else         → 1

New formula

	wep-ret_new(str) = 1 - ( str - 1 ) / ( str + 1 )

![weaponretforcemod](https://cloud.githubusercontent.com/assets/2611835/12704171/e4ee2ed6-c854-11e5-99b5-feabff3f1248.png)

`wep-ret_old` is blue, `wep-ret_new` is red. x-axis is strength, y-axis is WeaponRetForceMod. The [default strength of a `LifeForm` is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L12) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L194).