### PR TITLE
Change `LifeForm::ReloadSpeedMod`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -132,7 +132,7 @@ const float LifeForm::HealthRegen() const {
 }
 
 const float LifeForm::ReloadSpeedMod() const {
-	return 1.0f / getAgility();
+	return 2.0f / 2.0f * getAgility();
 }
 
 const float LifeForm::WeaponRetForceMod() const {


### PR DESCRIPTION
Old formula

    reload-speed-mod_old(agility) = 1 / agility

New formula

    reload-speed-mod_new(agility) = 2 / 2 * agility

![reloadspeedmod](https://cloud.githubusercontent.com/assets/2611835/12704238/826a9d38-c856-11e5-9df9-46560f963565.png)

`reload-speed-mod_old` is blue, `reload-speed-mod_new` is red. x-axis is agility, y-axis is ReloadSpeedMod. A `LifeForm`'s [initial agility is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L13) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L196)