### PR TITLE
Change `LifeForm::MaxSpeed`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -125,7 +125,7 @@ const int LifeForm::AttackDelay() const {
 }
 
 const float LifeForm::MaxSpeed() const {
-	return getAgility() / 5.0f;
+	return 1.5f * getAgility() / ( getAgility() * getWeight() + 7.5f );
 }
 
 const float LifeForm::HealthRegen() const {


### PR DESCRIPTION
Old formula

```
max-speed_old(agility) = agility / 5
```

New formula

```
max-speed_new(agility, weight) = 1.5 * agility / (agility * weight + 7.5)
```

![maxspeed](https://cloud.githubusercontent.com/assets/2611835/12704357/c38e75a2-c859-11e5-8b66-021b96ce0d7e.png)

`max-speed_old` is blue, `max-speed_new` is red. x-axis is agility, y-axis is MaxSpeed. `weight` is fixed as one.

A `LifeForm`'s [initial agility is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L13) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L196).
