### PR TITLE
Change `LifeForm::Damage`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -117,7 +117,7 @@ const bool LifeForm::Attack() {
 }
 
 const float LifeForm::Damage() const {
-	return getStrength() / 8.0f;
+	return getStrength() / ( getStrength() + 6.0f );
 }
 
 const int LifeForm::AttackDelay() const {


### PR DESCRIPTION
Old formula

    damage_old(str) = str / 8

New formula

    damage_new(str) = str / (str + 6)

![damage](https://cloud.githubusercontent.com/assets/2611835/12704424/22ee091c-c85b-11e5-8b34-2a307f742180.png)

`damage_old` is blue, `damage_new` is red. x-axis is strength, y-axis is Damage. The [default strength of a `LifeForm` is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L12) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L194).