### PR TITLE
Change `LifeForm::ChanceToEvade`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -100,7 +100,7 @@ const float LifeForm::MaxHealth() const {
 }
 
 const float LifeForm::ChanceToEvade() const {
-	float chance = (getAgility() - 1.0f) / 4.0f + (getStrength() - 1.0f) / 4.0f;
+	float chance = ( getAgility() + getStrength() - 2.0f ) / ( getAgility() + getStrength() + 2.0f );
 	if (chance < 0) chance = 0;
 	return chance;
 }


### PR DESCRIPTION
Old formula

    chance_old(agility, str) = (agility - 1) / 4 + (str - 1) / 4

New formula

    chance_new(agility, str) = (agility + str - 2 ) / (agility + str + 2)

This patch does not change the fact, that a chance cannot be negative.

--

**Visualization of change with fixed strength**

![chancetoevade-agility](https://cloud.githubusercontent.com/assets/2611835/12704553/32b36bbe-c85e-11e5-9245-33c1f1c77668.png)

`change_old` is blue, `change_new` is red. x-axis is agility (strength fixed at one), y-axis is ChanceToEvade.

--

**Visualization of change with fixed agility**

![chancetoevade-strengh](https://cloud.githubusercontent.com/assets/2611835/12704568/6463686c-c85e-11e5-9a6d-b28414816033.png)

`change_old` is blue, `change_new` is red. x-axis is strength (agility fixed at one), y-axis is ChanceToEvade.

--

A `LifeForm`'s [initial agility is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L13) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L196). The [default strength of a `LifeForm` is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L12) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L194).