### PR TITLE
Change `LifeForm::MaxHealth`

### DIFF
--- a/src/game/lifeforms/LifeForm.cpp
+++ b/src/game/lifeforms/LifeForm.cpp
@@ -95,8 +95,9 @@ void LifeForm::move(float direction, int deltaTime) {
 }
 
 const float LifeForm::MaxHealth() const {
-	return getVitality() > 0.8f ? 1.0f + (getVitality() - 1.0f) * 2.0f
-			+ (getStrength() - 1.0f) : 0.4f;
+	return ( getVitality() + getStrength() ) > 0.6f ?
+			( 4 * getVitality() + getStrength() ) / ( getStrength() + getVitality() + 3.0f )
+			: 0.2f;
 }
 
 const float LifeForm::ChanceToEvade() const {


### PR DESCRIPTION
Old formula

    max-health_old(vit, str) = if vit > 0.8       → (vit - 1) * 2 + (str - 1)
                               else               → 0.4

New formula

    max-health_new(vit, str) = if vit + str > 0.6 → (4 * vit + str) / (str + vit + 3)
                               else               → 0.2

--

**Visualization of change with fixed strengh**

![maxhealth-vitality](https://cloud.githubusercontent.com/assets/2611835/12704726/1463d7d6-c861-11e5-86ce-1322fcc95194.png)

`max-health-old` is blue, `max-health_new` is red. x-axis is vitality (strength is set to one), y-axis is MaxHealth.

--

**Visualization of change with fixed vitality**

![maxhealth-strength](https://cloud.githubusercontent.com/assets/2611835/12704742/9f9c0972-c861-11e5-8d22-f63f74fb6641.png)

`max-health-old` is blue, `max-health_new` is red. x-axis is strength (vitality is set to one), y-axis is MaxHealth.

--

A `LifeForm`'s [default vitality is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L14) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L199). The [default strength of a `LifeForm` is one](https://github.com/ooxi/violetland/blob/master/src/game/lifeforms/LifeForm.cpp#L12) and [increases slowly](https://github.com/ooxi/violetland/blob/master/src/windows/CharStatsWindow.cpp#L194).