### PR TITLE
Enable local README.md preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[+]` [Local preview of GitHub flavoured Markdown](https://github.com/ooxi/violetland/pull/127)
  * `[*]` [Violet will level up faster](https://github.com/ooxi/violetland/pull/115)
  * `[+]` [Windows executable uses GUI subsystem](https://github.com/ooxi/violetland/pull/111) thus not spawning a console
  * `[+]` [Icon for Windows executables](https://github.com/ooxi/violetland/pull/109)

--- a/deploy/vagrant/readme/README.md
+++ b/deploy/vagrant/readme/README.md
@@ -1,0 +1,28 @@
+Markdown preview
+================
+
+This Vagrant box will install [grip](https://github.com/joeyespo/grip) as local
+Markdown renderer, thus enabling preview of changes to e.g. `README.md` without
+pushing to GitHub.
+
+
+Usage
+-----
+
+    host> vagrant up
+    host> vagrant ssh
+    box> ./preview.sh
+    ^C
+    box> exit
+    host> vagrant destroy -f
+
+Executing `preview.sh` inside the Vagrant box will start `grip` at the root
+directory of the violetland repository. Since the Vagrant box is configured to
+forward port 6419 (default `grip` port) you should be able to accessing the
+`README.md` Markdown preview at
+
+    http://ip-of-host:6419/README.md
+
+The `preview.sh` script will also list all paths of Markdown files inside the
+repository.
+

--- a/deploy/vagrant/readme/Vagrantfile
+++ b/deploy/vagrant/readme/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+	config.vm.box = "ubuntu/trusty64"
+
+
+	# Sync source
+	config.vm.synced_folder "../../../", "/violetland"
+
+	# Forward grip port 6419
+	config.vm.network "forwarded_port", guest: 6419, host: 6419
+	
+	# Install grip via pip
+	config.vm.provision "shell", inline: <<-SHELL
+		apt-get update
+		apt-get install -y python-pip
+		pip install grip
+
+		cat <<EOT >> preview.sh
+#!/bin/bash
+
+bash -c "cd /violetland; find . -type f -iwholename '*.md'; grip . 0.0.0.0"
+EOT
+
+		chmod +x preview.sh
+	SHELL
+
+end
+
+


### PR DESCRIPTION
A new Vagrant box is provided, containing an automatic [grip](https://github.com/joeyespo/grip) installation and configuration. This enables local preview of Markdown rendered like GitHub would do.