### PR TITLE
Using `keyserver.ubuntu.com` instead of `keys.gnupg.net`

### DIFF
--- a/deploy/travis-ci/windows-amd64/before-install.sh
+++ b/deploy/travis-ci/windows-amd64/before-install.sh
@@ -11,7 +11,7 @@ source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
 PACKAGES='mxe-x86-64-w64-mingw32.static-gcc cmake mxe-x86-64-w64-mingw32.static-gettext mxe-x86-64-w64-mingw32.static-sdl mxe-x86-64-w64-mingw32.static-sdl-ttf mxe-x86-64-w64-mingw32.static-sdl-mixer mxe-x86-64-w64-mingw32.static-sdl-image mxe-x86-64-w64-mingw32.static-boost'
 
 echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
-sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+sudo apt-key adv --keyserver x-hkp://keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
 
 sudo apt-get update
 sudo apt-get install -y $PACKAGES

--- a/deploy/travis-ci/windows-i686/before-install.sh
+++ b/deploy/travis-ci/windows-i686/before-install.sh
@@ -11,7 +11,7 @@ source "${DIRECTORY_OF_THIS_FILE}/../travis-ci.sh"
 PACKAGES='mxe-i686-w64-mingw32.static-gcc cmake mxe-i686-w64-mingw32.static-gettext mxe-i686-w64-mingw32.static-sdl mxe-i686-w64-mingw32.static-sdl-ttf mxe-i686-w64-mingw32.static-sdl-mixer mxe-i686-w64-mingw32.static-sdl-image mxe-i686-w64-mingw32.static-boost'
 
 echo "deb http://pkg.mxe.cc/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
-sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+sudo apt-key adv --keyserver x-hkp://keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
 
 sudo apt-get update
 sudo apt-get install -y $PACKAGES


### PR DESCRIPTION
@starius [suggested](https://github.com/mxe/mxe/issues/1204#issuecomment-183085017) using `keyserver.ubuntu.com` instead of `keys.gnupg.net` since the former appears to be more stable.