### PR TITLE
Remove #pragma comment directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[!]` [Removed `#pragma comment` compiler warnings](https://github.com/ooxi/violetland/pull/135)
  * `[*]` [Violet will speed up slower](https://github.com/ooxi/violetland/pull/120)
  * `[*]` [Use standard libintl detection module](https://github.com/ooxi/violetland/pull/134)
  * `[+]` [Local preview of GitHub flavoured Markdown](https://github.com/ooxi/violetland/pull/127)

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1,12 +1,5 @@
 // MS Windows compatibility
 #ifdef _WIN32
-#pragma comment(lib, "SDL")
-#pragma comment(lib, "SDLmain")
-#pragma comment(lib, "SDL_image")
-#pragma comment(lib, "SDL_ttf")
-#pragma comment(lib, "SDL_mixer")
-#pragma comment(lib, "opengl32")
-#pragma comment(lib, "libintl")
 #define _USE_MATH_DEFINES
 #include <windows.h>
 #include <winbase.h>


### PR DESCRIPTION
Windows binaries are generated by CMake and MXE, thus `#pragma comment` directives are no longer necessary and only lead to compiler warnings.

Fixes issue #106.