### PR TITLE
Fix CMake gettext detection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/CMake-Gettext"]
 	path = lib/CMake-Gettext
-	url = https://github.com/jarro2783/CMake-Gettext.git
+	url = https://github.com/ooxi/CMake-Gettext.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[!]` [Fixed gettext detection](https://github.com/ooxi/violetland/pull/137)
  * `[!]` [Removed `#pragma comment` compiler warnings](https://github.com/ooxi/violetland/pull/135)
  * `[*]` [Violet will speed up slower](https://github.com/ooxi/violetland/pull/120)
  * `[*]` [Use standard libintl detection module](https://github.com/ooxi/violetland/pull/134)


### PR DESCRIPTION
`REQUIRE_BINARY` will be invoked with the result of a [find_program](https://cmake.org/cmake/help/v3.7/command/find_program.html) invocation. The old `REQUIRE_BINARY` implementation assumed, an unfound program would result in the definition of a second variable `VAR-NOTFOUND`. Instead the actual behaviour of `find_program` will assign the value `VAR-NOTFOUND` to the variable `VAR`. Thus the new implementation will catch errors finding programs while the old did not.

Moreover the error message is fixed, old output was `Could not find binname` while the new will substitue the variable `binname` thus resulting in e.g. `Could not find xgettext`.