### PR TITLE
Bumped CMake requirement to 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Legend
 Upcoming release
 ----------------
 
+ * `[!]` [Bumped CMake requirement to 3.2](https://github.com/ooxi/violetland/pull/144)
  * `[!]` [Fixed gettext detection](https://github.com/ooxi/violetland/pull/137)
  * `[!]` [Removed `#pragma comment` compiler warnings](https://github.com/ooxi/violetland/pull/135)
  * `[*]` [Violet will speed up slower](https://github.com/ooxi/violetland/pull/120)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,10 @@
 PROJECT(violetland)
 
-# CMake 2.8.10 documents the `CMAKE_<LANG>_COMPILER_ID' variable necessary to
-# identify Clang, otherwise we can go back to 2.6.0
-#
-# @see https://cmake.org/cmake/help/v2.8.10/cmake.html#variable:CMAKE_LANG_COMPILER_ID
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0 FATAL_ERROR)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+# CMake 3.2 is necessary in order to use FindIntl. If you want to compile
+# violetland on an older system (like plain Ubuntu 14.04) you can revert
+# da80351581f826f0f4c1c2f7b494ed51a6acec51 and it will work most likely down to
+# CMake 2.8.12
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
 
 
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Also your system must have the SDL packages (`SDL`, `SDL_image`, `SDL_ttf`, `SDL
 
 
 ### NOTE FOR UBUNTU USERS
-You should execute command like `sudo apt-get install cmake libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev` to install required packages (tested with Ubuntu 12.04).
+You should execute command like `sudo apt-get install cmake libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libboost-all-dev` to install required packages (tested with Ubuntu 16.04+).
 
 Besides, some additional steps are required.
 


### PR DESCRIPTION
CMake 3.2 is required in order to use [FindIntl](https://cmake.org/cmake/help/v3.2/module/FindIntl.html). This also implicitly raises the requirement to Ubuntu 16.04 since Ubuntu 14.04 ships with CMake 2.8.12 by default.